### PR TITLE
Fix the "Input file Specified Two Times" Error.

### DIFF
--- a/xnLinkFinder.py
+++ b/xnLinkFinder.py
@@ -2088,7 +2088,7 @@ if __name__ == "__main__":
             try:
                 filePath = os.path.abspath(args.output).replace(" ", "\ ")
 
-                # Fixes the "Input file specified 2 times" error message.
+                # Multi-OS support
                 if os.name != 'nt':
                     cmd = "sort -u -o " + args.output + " " + args.output
                 else:
@@ -2099,7 +2099,6 @@ if __name__ == "__main__":
             except Exception as e:
                 if vverbose():
                     print(colored("ERROR main 2: " + str(e), "red"))
-
 
     except Exception as e:
         if vverbose():

--- a/xnLinkFinder.py
+++ b/xnLinkFinder.py
@@ -2087,13 +2087,19 @@ if __name__ == "__main__":
         if args.output != "cli":
             try:
                 filePath = os.path.abspath(args.output).replace(" ", "\ ")
-                cmd = "sort -u -o " + args.output + " " + args.output
+
+                # Fixes the "Input file specified 2 times" error message.
+                if os.name != 'nt':
+                    cmd = "sort -u -o " + args.output + " " + args.output
+                else:
+                    cmd = "sort /unique /o " + args.output + " " + args.output
                 sort = subprocess.run(
                     cmd, shell=True, text=True, stdout=subprocess.PIPE, check=True
                 )
             except Exception as e:
                 if vverbose():
                     print(colored("ERROR main 2: " + str(e), "red"))
+
 
     except Exception as e:
         if vverbose():


### PR DESCRIPTION
Hi!

The error was being shown due to the lack of Windows/Linux compatibility in the `sort` command being used.
The pull request takes care of this issue by checking the current OS.

Thanks!