### PR TITLE
Remove argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author="@xnl-h4ck3r",
     url="https://github.com/xnl-h4ck3r/xnlLinkFinder",
     py_modules=["xnLinkFinder"],
-    install_requires=["argparse","requests","psutil","pyyaml","termcolor","urlparse3","beautifulsoup4","lxml","html5lib","urllib3"],
+    install_requires=["requests","psutil","pyyaml","termcolor","urlparse3","beautifulsoup4","lxml","html5lib","urllib3"],
     entry_points={
         'console_scripts': [
             'xnLinkFinder = xnLinkFinder.xnLinkFinder:main',


### PR DESCRIPTION
`argparse` is a Python [standard](https://docs.python.org/3/library/argparse.html) module.